### PR TITLE
Applied commit from graphopper to fix 2^31 limit

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,9 +13,12 @@
  * drnextgis, ru translation and JS fixes
  * duongnt, fixes in storage
  * lmar, improved instructions information
+ * fbonzon, UI improvements like #615
  * florent-morel, improvements regarding fords, #320
  * fredao, translations 
  * henningvs, doc improvements
+ * highsource, more efficient geometry update, ui fixes
+ * IsNull, improvements like #708
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config
  * JohannesPelzer, improved GPX information and various other things

--- a/android/app/pom.xml
+++ b/android/app/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-android</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-1-SNAPSHOT</version>
     <name>GraphHopper Android</name>
     <packaging>apk</packaging>    
     <organization>
@@ -16,7 +16,7 @@
         <relativePath>../..</relativePath>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-1-SNAPSHOT</version>
     </parent>
     <properties>
         <mapsforge.version>0.5.2</mapsforge.version>

--- a/android/app/pom.xml
+++ b/android/app/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-android</artifactId>
-    <version>0.6-kmt-1-SNAPSHOT</version>
+    <version>0.6-kmt-1</version>
     <name>GraphHopper Android</name>
     <packaging>apk</packaging>    
     <organization>
@@ -16,7 +16,7 @@
         <relativePath>../..</relativePath>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-kmt-1-SNAPSHOT</version>
+        <version>0.6-kmt-1</version>
     </parent>
     <properties>
         <mapsforge.version>0.5.2</mapsforge.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper</artifactId>
     <name>GraphHopper</name>
-    <version>0.6-kmt-1-SNAPSHOT</version>
+    <version>0.6-kmt-1</version>
     <packaging>jar</packaging> 
     <description>
         GraphHopper is a fast and memory efficient Java road routing engine 
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-kmt-1-SNAPSHOT</version>
+        <version>0.6-kmt-1</version>
     </parent>
         
     <properties>  

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper</artifactId>
     <name>GraphHopper</name>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-1-SNAPSHOT</version>
     <packaging>jar</packaging> 
     <description>
         GraphHopper is a fast and memory efficient Java road routing engine 
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-1-SNAPSHOT</version>
     </parent>
         
     <properties>  

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -28,6 +28,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.search.NameIndex;
 import com.graphhopper.util.*;
 import static com.graphhopper.util.Helper.nf;
+
 import com.graphhopper.util.shapes.BBox;
 import java.io.UnsupportedEncodingException;
 
@@ -438,6 +439,11 @@ class BaseGraph implements Graph
                 + wayGeometry.getCapacity() + extStorage.getCapacity();
     }
 
+    long getMaxGeoRef()
+    {
+        return maxGeoRef;
+    }
+
     void loadExisting( String dim )
     {
         if (!nodes.loadExisting())
@@ -827,39 +833,67 @@ class BaseGraph implements Graph
                 throw new IllegalArgumentException("Cannot use pointlist which is " + pillarNodes.getDimension()
                         + "D for graph which is " + nodeAccess.getDimension() + "D");
 
+            long existingGeoRef = Helper.toUnsignedLong(edges.getInt(edgePointer + E_GEO));
+
             int len = pillarNodes.getSize();
             int dim = nodeAccess.getDimension();
-            int tmpRef = nextGeoRef(len * dim);
-            edges.setInt(edgePointer + E_GEO, tmpRef);
-            long geoRef = (long) tmpRef * 4;
-            byte[] bytes = new byte[len * dim * 4 + 4];
-            ensureGeometry(geoRef, bytes.length);
-            bitUtil.fromInt(bytes, len, 0);
-            if (reverse)
-                pillarNodes.reverse();
-
-            int tmpOffset = 4;
-            boolean is3D = nodeAccess.is3D();
-            for (int i = 0; i < len; i++)
+            if (existingGeoRef > 0)
             {
-                double lat = pillarNodes.getLatitude(i);
-                bitUtil.fromInt(bytes, Helper.degreeToInt(lat), tmpOffset);
-                tmpOffset += 4;
-                bitUtil.fromInt(bytes, Helper.degreeToInt(pillarNodes.getLongitude(i)), tmpOffset);
-                tmpOffset += 4;
-
-                if (is3D)
+                final int count = wayGeometry.getInt(existingGeoRef * 4L);
+                if (len <= count)
                 {
-                    bitUtil.fromInt(bytes, Helper.eleToInt(pillarNodes.getElevation(i)), tmpOffset);
-                    tmpOffset += 4;
+                    setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, existingGeoRef);
+                    return;
                 }
             }
 
-            wayGeometry.setBytes(geoRef, bytes, bytes.length);
+            long nextGeoRef = nextGeoRef(len * dim);
+            setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, nextGeoRef);
         } else
         {
             edges.setInt(edgePointer + E_GEO, 0);
         }
+    }
+
+    private void setWayGeometryAtGeoRef( PointList pillarNodes, long edgePointer, boolean reverse, long geoRef )
+    {
+        int len = pillarNodes.getSize();
+        int dim = nodeAccess.getDimension();
+        long geoRefPosition = (long) geoRef * 4;
+        int totalLen = len * dim * 4 + 4;
+        ensureGeometry(geoRefPosition, totalLen);
+        byte[] wayGeometryBytes = createWayGeometryBytes(pillarNodes, reverse);
+        wayGeometry.setBytes(geoRefPosition, wayGeometryBytes, wayGeometryBytes.length);
+        edges.setInt(edgePointer + E_GEO, Helper.toSignedInt(geoRef));
+    }
+
+    private byte[] createWayGeometryBytes( PointList pillarNodes, boolean reverse )
+    {
+        int len = pillarNodes.getSize();
+        int dim = nodeAccess.getDimension();
+        int totalLen = len * dim * 4 + 4;
+        byte[] bytes = new byte[totalLen];
+        bitUtil.fromInt(bytes, len, 0);
+        if (reverse)
+            pillarNodes.reverse();
+
+        int tmpOffset = 4;
+        boolean is3D = nodeAccess.is3D();
+        for (int i = 0; i < len; i++)
+        {
+            double lat = pillarNodes.getLatitude(i);
+            bitUtil.fromInt(bytes, Helper.degreeToInt(lat), tmpOffset);
+            tmpOffset += 4;
+            bitUtil.fromInt(bytes, Helper.degreeToInt(pillarNodes.getLongitude(i)), tmpOffset);
+            tmpOffset += 4;
+
+            if (is3D)
+            {
+                bitUtil.fromInt(bytes, Helper.eleToInt(pillarNodes.getElevation(i)), tmpOffset);
+                tmpOffset += 4;
+            }
+        }
+        return bytes;
     }
 
     private PointList fetchWayGeometry_( long edgePointer, boolean reverse, int mode, int baseNode, int adjNode )
@@ -910,6 +944,7 @@ class BaseGraph implements Graph
         {
             if ((mode & 1) != 0)
                 pillarNodes.add(nodeAccess, baseNode);
+            
             pillarNodes.reverse();
         } else
         {

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -130,6 +130,22 @@ public class Helper
         }
     }
 
+    /**
+     * This method handles the specified (potentially negative) int as unsigned bit representation
+     * and returns the positive converted long. Copied from 0.13 version of Graphhopper
+     */
+    public static final long toUnsignedLong(int x) {
+        return ((long) x) & 0xFFFFffffL;
+    }
+
+    /**
+     * Converts the specified long back into a signed int (reverse method for toUnsignedLong)
+     * Copied from 0.13 version of Graphhopper
+     */
+    public static final int toSignedInt(long x) {
+        return (int) x;
+    }
+
     public static void saveProperties( Map<String, String> map, Writer tmpWriter ) throws IOException
     {
         BufferedWriter writer = new BufferedWriter(tmpWriter);

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
+import java.io.IOException;
 
 /**
  * Abstract test class to be extended for implementations of the Graph interface. Graphs
@@ -1077,6 +1078,34 @@ public abstract class AbstractGraphStorageTester
         assertEquals(Helper.createPointList3D(10, 27, 72, 11, 20, 1), GHUtility.getEdge(graph, 0, 1).fetchWayGeometry(0));
         assertEquals(Helper.createPointList3D(10, 20, -10, 10, 27, 72, 11, 20, 1, 11, 2, 100), GHUtility.getEdge(graph, 0, 1).fetchWayGeometry(3));
         assertEquals(Helper.createPointList3D(11, 2, 100, 11, 20, 1, 10, 27, 72, 10, 20, -10), GHUtility.getEdge(graph, 1, 0).fetchWayGeometry(3));
+    }
+
+    @Test
+    public void testDontGrowOnUpdate() throws IOException
+    {
+        graph = createGHStorage(defaultGraphLoc, true);
+        NodeAccess na = graph.getNodeAccess();
+        assertTrue(na.is3D());
+        na.setNode(0, 10, 10, 0);
+        na.setNode(1, 11, 20, 1);
+        na.setNode(2, 12, 12, 0.4);
+
+        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true);
+        final BaseGraph baseGraph = (BaseGraph) graph.getBaseGraph();
+        assertEquals(4, baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
+        assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
+        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
+        assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -170,35 +170,6 @@
     <!-- mvn deploy -DperformRelease=true -->
     <profiles>
         <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
-        <profile>
             <id>include-android</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-1-SNAPSHOT</version>
     <packaging>pom</packaging> 
     <url>http://graphhopper.com</url> 
     <inceptionYear>2012</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
+                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>performRelease</name>
                     <value>true</value>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>0.6-kmt-1-SNAPSHOT</version>
+    <version>0.6-kmt-1</version>
     <packaging>pom</packaging> 
     <url>http://graphhopper.com</url> 
     <inceptionYear>2012</inceptionYear>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-tools</artifactId>
-    <version>0.6-kmt-1-SNAPSHOT</version>
+    <version>0.6-kmt-1</version>
     <packaging>jar</packaging>
     <name>GraphHopper Tools</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-kmt-1-SNAPSHOT</version>
+        <version>0.6-kmt-1</version>
     </parent>
 
     <dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-tools</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>GraphHopper Tools</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,14 +6,14 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-web</artifactId>
     <packaging>jar</packaging>
-    <version>0.6-kmt-1-SNAPSHOT</version>
+    <version>0.6-kmt-1</version>
     <name>GraphHopper Web</name>
     <description>Example on how to use GraphHopper in a web-based application</description>
         
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-kmt-1-SNAPSHOT</version>
+        <version>0.6-kmt-1</version>
     </parent>
     <properties>
         <jetty.version>8.1.16.v20140903</jetty.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,14 +6,14 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-web</artifactId>
     <packaging>jar</packaging>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-1-SNAPSHOT</version>
     <name>GraphHopper Web</name>
     <description>Example on how to use GraphHopper in a web-based application</description>
         
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-1-SNAPSHOT</version>
     </parent>
     <properties>
         <jetty.version>8.1.16.v20140903</jetty.version>


### PR DESCRIPTION
Applied https://github.com/graphhopper/graphhopper/commit/dfd62e2c8fa73f95eceed05b918cb607fdaac813
Limit is now 2^32
More here:https://github.com/graphhopper/graphhopper/issues/500

As far as I understand this lowers elevation resolution to gain one byte for nodes and edges.

I included this in Wanderwalter and did some tests.

Interestingly graph in Wanderwalter builds now 4 times faster. Berlin MTB builds in 2 minutes compared to 9 before this commit. With this change we can revert the accuracy change. But there are little differences in routing with this change. Elevation has different numbers behind the decimal point. Probably thats also why times are little different.

So for example you have (on the left current numbers, on the right wanderwalter with this change):
```
 "distance": 4360.252475524618,                       |    "distance": 4360.250127302266,                                   
  "duration": 875.6984803969996,                      |    "duration": 875.2314631560797,                                   
  "elevation_up": 25.478052146835964,                 |    "elevation_up": 25.413630743806642,                              
  "elevation_down": 14.382152649922595,               |    "elevation_down": 14.463908250080777,                       
```
At the end all the differences are after decimal point. I tested [this](https://www.komoot.com/plan/tour/d06AyGebADMTE0=FxYABLYfbxAA/@52.5135048,13.4077835,12z) query.

This can be applied now and we can update wanderwalter in the meantime but still have nice imports without accuracy loss.