### PR TITLE
Applied commit from graphopper to fix 2^31 limit  take 2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,10 +12,12 @@
  * dos65, bug fixes in routing algo
  * drnextgis, ru translation and JS fixes
  * duongnt, fixes in storage
- * lmar, improved instructions information
+ * fbonzon, UI improvements like #615
  * florent-morel, improvements regarding fords, #320
  * fredao, translations 
  * henningvs, doc improvements
+ * highsource, more efficient geometry update, ui fixes
+ * IsNull, improvements like #708
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config
  * JohannesPelzer, improved GPX information and various other things

--- a/android/app/pom.xml
+++ b/android/app/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-android</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-3</version>
     <name>GraphHopper Android</name>
     <packaging>apk</packaging>    
     <organization>
@@ -16,7 +16,7 @@
         <relativePath>../..</relativePath>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-3</version>
     </parent>
     <properties>
         <mapsforge.version>0.5.2</mapsforge.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper</artifactId>
     <name>GraphHopper</name>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-3</version>
     <packaging>jar</packaging> 
     <description>
         GraphHopper is a fast and memory efficient Java road routing engine 
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-3</version>
     </parent>
         
     <properties>  

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -28,6 +28,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.search.NameIndex;
 import com.graphhopper.util.*;
 import static com.graphhopper.util.Helper.nf;
+
 import com.graphhopper.util.shapes.BBox;
 import java.io.UnsupportedEncodingException;
 
@@ -439,6 +440,11 @@ class BaseGraph implements Graph
                 + wayGeometry.getCapacity() + extStorage.getCapacity();
     }
 
+    long getMaxGeoRef()
+    {
+        return maxGeoRef;
+    }
+
     void loadExisting( String dim )
     {
         if (!nodes.loadExisting())
@@ -828,39 +834,67 @@ class BaseGraph implements Graph
                 throw new IllegalArgumentException("Cannot use pointlist which is " + pillarNodes.getDimension()
                         + "D for graph which is " + nodeAccess.getDimension() + "D");
 
+            long existingGeoRef = Helper.toUnsignedLong(edges.getInt(edgePointer + E_GEO));
+
             int len = pillarNodes.getSize();
             int dim = nodeAccess.getDimension();
-            long tmpRef = nextGeoRef(len * dim);
-            edges.setInt(edgePointer + E_GEO, Helper.toSignedInt(tmpRef));
-            long geoRef = (long) tmpRef * 4;
-            byte[] bytes = new byte[len * dim * 4 + 4];
-            ensureGeometry(geoRef, bytes.length);
-            bitUtil.fromInt(bytes, len, 0);
-            if (reverse)
-                pillarNodes.reverse();
-
-            int tmpOffset = 4;
-            boolean is3D = nodeAccess.is3D();
-            for (int i = 0; i < len; i++)
+            if (existingGeoRef > 0)
             {
-                double lat = pillarNodes.getLatitude(i);
-                bitUtil.fromInt(bytes, Helper.degreeToInt(lat), tmpOffset);
-                tmpOffset += 4;
-                bitUtil.fromInt(bytes, Helper.degreeToInt(pillarNodes.getLongitude(i)), tmpOffset);
-                tmpOffset += 4;
-
-                if (is3D)
+                final int count = wayGeometry.getInt(existingGeoRef * 4L);
+                if (len <= count)
                 {
-                    bitUtil.fromInt(bytes, Helper.eleToInt(pillarNodes.getElevation(i)), tmpOffset);
-                    tmpOffset += 4;
+                    setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, existingGeoRef);
+                    return;
                 }
             }
 
-            wayGeometry.setBytes(geoRef, bytes, bytes.length);
+            long nextGeoRef = nextGeoRef(len * dim);
+            setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, nextGeoRef);
         } else
         {
             edges.setInt(edgePointer + E_GEO, 0);
         }
+    }
+
+    private void setWayGeometryAtGeoRef( PointList pillarNodes, long edgePointer, boolean reverse, long geoRef )
+    {
+        int len = pillarNodes.getSize();
+        int dim = nodeAccess.getDimension();
+        long geoRefPosition = (long) geoRef * 4;
+        int totalLen = len * dim * 4 + 4;
+        ensureGeometry(geoRefPosition, totalLen);
+        byte[] wayGeometryBytes = createWayGeometryBytes(pillarNodes, reverse);
+        wayGeometry.setBytes(geoRefPosition, wayGeometryBytes, wayGeometryBytes.length);
+        edges.setInt(edgePointer + E_GEO, Helper.toSignedInt(geoRef));
+    }
+
+    private byte[] createWayGeometryBytes( PointList pillarNodes, boolean reverse )
+    {
+        int len = pillarNodes.getSize();
+        int dim = nodeAccess.getDimension();
+        int totalLen = len * dim * 4 + 4;
+        byte[] bytes = new byte[totalLen];
+        bitUtil.fromInt(bytes, len, 0);
+        if (reverse)
+            pillarNodes.reverse();
+
+        int tmpOffset = 4;
+        boolean is3D = nodeAccess.is3D();
+        for (int i = 0; i < len; i++)
+        {
+            double lat = pillarNodes.getLatitude(i);
+            bitUtil.fromInt(bytes, Helper.degreeToInt(lat), tmpOffset);
+            tmpOffset += 4;
+            bitUtil.fromInt(bytes, Helper.degreeToInt(pillarNodes.getLongitude(i)), tmpOffset);
+            tmpOffset += 4;
+
+            if (is3D)
+            {
+                bitUtil.fromInt(bytes, Helper.eleToInt(pillarNodes.getElevation(i)), tmpOffset);
+                tmpOffset += 4;
+            }
+        }
+        return bytes;
     }
 
     private PointList fetchWayGeometry_( long edgePointer, boolean reverse, int mode, int baseNode, int adjNode )
@@ -911,6 +945,7 @@ class BaseGraph implements Graph
         {
             if ((mode & 1) != 0)
                 pillarNodes.add(nodeAccess, baseNode);
+            
             pillarNodes.reverse();
         } else
         {

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -78,9 +78,9 @@ class BaseGraph implements Graph
     final NodeAccess nodeAccess;
     final GraphExtension extStorage;
     // length | nodeA | nextNode | ... | nodeB
-    // as we use integer index in 'egdes' area => 'geometry' area is limited to 2GB (currently ~311M for world wide)
-    final DataAccess wayGeometry;
-    private int maxGeoRef;
+    // as we use integer index in 'egdes' area => 'geometry' area is limited to 4GB (we use pos&neg values!)
+    private final DataAccess wayGeometry;
+    private long maxGeoRef;
     final NameIndex nameIndex;
     final BitUtil bitUtil;
     private final Directory dir;
@@ -225,13 +225,14 @@ class BaseGraph implements Graph
 
     protected int loadWayGeometryHeader()
     {
-        maxGeoRef = wayGeometry.getHeader(0);
+        maxGeoRef = bitUtil.combineIntsToLong(wayGeometry.getHeader(0), wayGeometry.getHeader(4));
         return 1;
     }
 
     protected int setWayGeometryHeader()
     {
-        wayGeometry.setHeader(0, maxGeoRef);
+        wayGeometry.setHeader(0, bitUtil.getIntLow(maxGeoRef));
+        wayGeometry.setHeader(4, bitUtil.getIntHigh(maxGeoRef));
         return 1;
     }
 
@@ -829,8 +830,8 @@ class BaseGraph implements Graph
 
             int len = pillarNodes.getSize();
             int dim = nodeAccess.getDimension();
-            int tmpRef = nextGeoRef(len * dim);
-            edges.setInt(edgePointer + E_GEO, tmpRef);
+            long tmpRef = nextGeoRef(len * dim);
+            edges.setInt(edgePointer + E_GEO, Helper.toSignedInt(tmpRef));
             long geoRef = (long) tmpRef * 4;
             byte[] bytes = new byte[len * dim * 4 + 4];
             ensureGeometry(geoRef, bytes.length);
@@ -864,15 +865,15 @@ class BaseGraph implements Graph
 
     private PointList fetchWayGeometry_( long edgePointer, boolean reverse, int mode, int baseNode, int adjNode )
     {
-        long geoRef = edges.getInt(edgePointer + E_GEO);
+        long geoRef = Helper.toUnsignedLong(edges.getInt(edgePointer + E_GEO));
         int count = 0;
         byte[] bytes = null;
         if (geoRef > 0)
         {
-            geoRef *= 4;
+            geoRef *= 4L;
             count = wayGeometry.getInt(geoRef);
 
-            geoRef += 4;
+            geoRef += 4L;
             bytes = new byte[count * nodeAccess.getDimension() * 4];
             wayGeometry.getBytes(geoRef, bytes, bytes.length);
         } else if (mode == 0)
@@ -949,11 +950,13 @@ class BaseGraph implements Graph
         wayGeometry.ensureCapacity(bytePos + byteLength);
     }
 
-    private int nextGeoRef( int arrayLength )
+    private long nextGeoRef( int arrayLength )
     {
-        int tmp = maxGeoRef;
-        // one more integer to store also the size itself
-        maxGeoRef += arrayLength + 1;
+        long tmp = maxGeoRef;
+        maxGeoRef += arrayLength + 1L;
+        if (maxGeoRef >= 0xFFFFffffL)
+            throw new IllegalStateException("Geometry too large, does not fit in 32 bits " + maxGeoRef);
+
         return tmp;
     }
 

--- a/core/src/main/java/com/graphhopper/util/Constants.java
+++ b/core/src/main/java/com/graphhopper/util/Constants.java
@@ -53,7 +53,7 @@ public class Constants
     public static final String OS_VERSION = System.getProperty("os.version");
     public static final String JAVA_VENDOR = System.getProperty("java.vendor");
     public static final int VERSION_NODE = 4;
-    public static final int VERSION_EDGE = 12;
+    public static final int VERSION_EDGE = 13;
     public static final int VERSION_SHORTCUT = 1;
     public static final int VERSION_GEOMETRY = 3;
     public static final int VERSION_LOCATION_IDX = 2;

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -496,4 +496,22 @@ public class Helper
     {
         return Math.round(value * 100) / 100d;
     }
+
+
+    /**
+     * This method handles the specified (potentially negative) int as unsigned bit representation
+     * and returns the positive converted long.
+     */
+    public static final long toUnsignedLong( int x )
+    {
+        return ((long) x) & 0xFFFFffffL;
+    }
+
+    /**
+     * Converts the specified long back into a signed int (reverse method for toUnsignedLong)
+     */
+    public static final int toSignedInt( long x )
+    {
+        return (int) x;
+    }
 }

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
+import java.io.IOException;
 
 /**
  * Abstract test class to be extended for implementations of the Graph interface. Graphs
@@ -1077,6 +1078,34 @@ public abstract class AbstractGraphStorageTester
         assertEquals(Helper.createPointList3D(10, 27, 72, 11, 20, 1), GHUtility.getEdge(graph, 0, 1).fetchWayGeometry(0));
         assertEquals(Helper.createPointList3D(10, 20, -10, 10, 27, 72, 11, 20, 1, 11, 2, 100), GHUtility.getEdge(graph, 0, 1).fetchWayGeometry(3));
         assertEquals(Helper.createPointList3D(11, 2, 100, 11, 20, 1, 10, 27, 72, 10, 20, -10), GHUtility.getEdge(graph, 1, 0).fetchWayGeometry(3));
+    }
+
+    @Test
+    public void testDontGrowOnUpdate() throws IOException
+    {
+        graph = createGHStorage(defaultGraphLoc, true);
+        NodeAccess na = graph.getNodeAccess();
+        assertTrue(na.is3D());
+        na.setNode(0, 10, 10, 0);
+        na.setNode(1, 11, 20, 1);
+        na.setNode(2, 12, 12, 0.4);
+
+        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true);
+        final BaseGraph baseGraph = (BaseGraph) graph.getBaseGraph();
+        assertEquals(4, baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3));
+        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
+        assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
+        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
+        assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/util/HelperTest.java
+++ b/core/src/test/java/com/graphhopper/util/HelperTest.java
@@ -89,4 +89,27 @@ public class HelperTest
         assertEquals(3, Helper.keepIn(2, 3, 4), 1e-2);
         assertEquals(3, Helper.keepIn(-2, 3, 4), 1e-2);
     }
+
+    @Test
+    public void testUnsignedConversions()
+    {
+        long l = Helper.toUnsignedLong(-1);
+        assertEquals(4294967295L, l);
+        assertEquals(-1, Helper.toSignedInt(l));
+
+        int intVal = Integer.MAX_VALUE;
+        long maxInt = (long) intVal;
+        assertEquals(intVal, Helper.toSignedInt(maxInt));
+
+        intVal++;
+        maxInt = Helper.toUnsignedLong(intVal);
+        assertEquals(intVal, Helper.toSignedInt(maxInt));
+
+        intVal++;
+        maxInt = Helper.toUnsignedLong(intVal);
+        assertEquals(intVal, Helper.toSignedInt(maxInt));
+
+        assertEquals(0xFFFFffffL, (1L << 32) - 1);
+        assertTrue(0xFFFFffffL > 0L);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-3</version>
     <packaging>pom</packaging> 
     <url>http://graphhopper.com</url> 
     <inceptionYear>2012</inceptionYear>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-tools</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-3</version>
     <packaging>jar</packaging>
     <name>GraphHopper Tools</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-3</version>
     </parent>
 
     <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,14 +6,14 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-web</artifactId>
     <packaging>jar</packaging>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6-kmt-3</version>
     <name>GraphHopper Web</name>
     <description>Example on how to use GraphHopper in a web-based application</description>
         
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.6-SNAPSHOT</version>
+        <version>0.6-kmt-3</version>
     </parent>
     <properties>
         <jetty.version>8.1.16.v20140903</jetty.version>


### PR DESCRIPTION
Applied https://github.com/graphhopper/graphhopper/commit/40837026e72485ca139ce392d3cbb7225afb9210
and https://github.com/graphhopper/graphhopper/commit/dfd62e2c8fa73f95eceed05b918cb607fdaac813
Limit is now 2^32
More here:https://github.com/graphhopper/graphhopper/issues/500

In addition to PR https://github.com/komoot/graphhopper/pull/1 this also adds commit which changes storage of geometry pointers from int to long.

As far as I understand this lowers elevation resolution to gain one byte for nodes and edges.

I included this in Wanderwalter and did some tests.

Interestingly graph in Wanderwalter builds now 4 times faster. Berlin MTB builds in 2 minutes compared to 9 before this commit. With this change we can revert the accuracy change. But there are little differences in routing with this change. Elevation has different numbers behind the decimal point. Probably thats also why times are little different.

So for example you have (on the left current numbers, on the right wanderwalter with this change):
```
 "distance": 4360.252475524618,                       |    "distance": 4360.250127302266,                                   
  "duration": 875.6984803969996,                      |    "duration": 875.2314631560797,                                   
  "elevation_up": 25.478052146835964,                 |    "elevation_up": 25.413630743806642,                              
  "elevation_down": 14.382152649922595,               |    "elevation_down": 14.463908250080777,                       
```
At the end all the differences are after decimal point. I tested [this](https://www.komoot.com/plan/tour/d06AyGebADMTE0=FxYABLYfbxAA/@52.5135048,13.4077835,12z) query.

This can be applied now and we can update wanderwalter in the meantime but still have nice imports without accuracy loss.